### PR TITLE
Fix typo in QKVBimodalCSRPool

### DIFF
--- a/torch_points3d/modules/multimodal/pooling.py
+++ b/torch_points3d/modules/multimodal/pooling.py
@@ -491,7 +491,7 @@ class QKVBimodalCSRPool(nn.Module, ABC):
 
             # Compute view-wise queries : V x (D x num_groups)
             x_mix = self.E_mix_Q(torch.cat([x_main_q, x_mod], dim=1))
-            keys = self.Q(x_mix)
+            queries = self.Q(x_mix)
         else:
             # Compute pointwise queries : N x (D x num_groups)
             queries = self.Q(x_main)


### PR DESCRIPTION
Hello @drprojects ,

as I was going through the `QKVBimodalCSRPool` code I noticed that the code overwrites the `keys` when `use_mod_q` is true, then on line 506 `queries` is referenced without being defined which causes an error on my end.  And as far as I understand the transform `self.Q` should be used for getting the query embeddings.

I thought this small change would fix the bug. Thank you once again for your work and making it available! 